### PR TITLE
fix(bot): accept bot_id/grid_id as string to avoid float64 precision loss

### DIFF
--- a/src/tools/bot/closeComboBot.ts
+++ b/src/tools/bot/closeComboBot.ts
@@ -6,7 +6,7 @@ export const closeComboBot = {
   name: 'closeComboBot',
   description: "Closes (stops) a running futures combo trading bot. The bot will cancel\nall pending orders and close all positions across the portfolio.\n\nThe bot_id can be obtained from the createComboBot response or from\ngetComboDetail. Only bots in a running state can be closed.\n\nRate limit: 10 requests per second per UID.\n\nAgent hint: Use this to stop a running combo bot. The bot_id is required and can be\nfound in the createComboBot response. The stop_type indicates the reason\nfor closing. After closing, use getComboDetail to check the final PnL\nand close reason.",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
     stop_type: z.enum(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"]).optional(),
   }),
   handler: async (input: Record<string, unknown>) => {

--- a/src/tools/bot/closeDCABot.ts
+++ b/src/tools/bot/closeDCABot.ts
@@ -6,7 +6,7 @@ export const closeDCABot = {
   name: 'closeDCABot',
   description: "Closes a running DCA bot. You must specify a close_mode to determine\nhow remaining assets are settled:\n- 1 (DCA_BIT_MODE): settle in BIT\n- 2 (DCA_BASE_MODE): convert all to base tokens\n- 3 (DCA_QUOTE_MODE): convert all to quote token\n\nThe bot must be in a closeable state. Bots that are currently in the\nmiddle of an investment cycle may not be closeable (status_code=503).\n\nRate limit: 3 qps per UID.\n\nAgent hint: Use close_mode=3 (DCA_QUOTE_MODE) if the user wants to convert\neverything back to the quote coin (e.g., USDT).",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
     close_mode: z.enum(["1", "2", "3"]),
   }),
   handler: async (input: Record<string, unknown>) => {

--- a/src/tools/bot/closeFGridBot.ts
+++ b/src/tools/bot/closeFGridBot.ts
@@ -6,7 +6,7 @@ export const closeFGridBot = {
   name: 'closeFGridBot',
   description: "Closes (stops) a running futures grid trading bot. The bot will cancel\nall pending grid orders and close positions.\n\nThe bot_id can be obtained from the createFGridBot response or from\ngetFGridDetail. Only bots in a running state can be closed.\n\nRate limit: 10 requests per second per UID.\n\nAgent hint: Use this to stop a running grid bot. The bot_id is required and can be\nfound in the createFGridBot response. After closing, use getFGridDetail\nto check the final PnL and close reason.",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
   }),
   handler: async (input: Record<string, unknown>) => {
     return restClient.postAuth("/v5/fgridbot/close", input);

--- a/src/tools/bot/closeFMartBot.ts
+++ b/src/tools/bot/closeFMartBot.ts
@@ -6,7 +6,7 @@ export const closeFMartBot = {
   name: 'closeFMartBot',
   description: "Closes (stops) a running futures Martingale trading bot. The bot will\ncancel all pending orders and close the position.\n\nThe bot_id can be obtained from the createFMartBot response or from\ngetFMartDetail. Only bots in a running state can be closed.\n\nRate limit: 10 requests per second per UID.\n\nAgent hint: Use this to stop a running Martingale bot. The bot_id is required and\ncan be found in the createFMartBot response. The stop_type indicates\nthe reason for closing. After closing, use getFMartDetail to check the\nfinal PnL and close reason.",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
     stop_type: z.enum(["F_MART_BOT_STOP_TYPE_STOP_TYPE_UNKNOWN_UNSPECIFIED", "F_MART_BOT_STOP_TYPE_STOP_TYPE_INIT_ERROR", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_USER", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_LIQ", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_SYMBOL_OFFLINE", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_SL", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_SYSTEM", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_USER_BANNED", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_TP_SINGLE_ROUND", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_ORDER_COST", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_REDUCE_ONLY", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_BUST_PRICE", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_NEGATIVE_ARBITRAGE", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_COMPLIANCE", "F_MART_BOT_STOP_TYPE_STOP_TYPE_BY_ADL"]).optional(),
   }),
   handler: async (input: Record<string, unknown>) => {

--- a/src/tools/bot/closeGridBot.ts
+++ b/src/tools/bot/closeGridBot.ts
@@ -6,7 +6,7 @@ export const closeGridBot = {
   name: 'closeGridBot',
   description: "Closes a running spot grid bot. You must specify a close_mode to\ndetermine how remaining assets are settled:\n- 1 (BIT_MODE): settle in BIT\n- 2 (BASE_MODE): convert all to base token\n- 3 (QUOTE_MODE): convert all to quote token\n- 4 (BASE_AND_QUOTE_MODE): return assets as-is, no conversion\n\nThe bot must be in a closeable state (NEW or RUNNING). Bots in\nCANCELLING or COMPLETED state cannot be closed again.\n\nRate limit: 3 qps per UID.\n\nAgent hint: Use close_mode=3 (QUOTE_MODE) if the user wants to cash out to\nstablecoin. Use close_mode=4 if the user wants to keep both tokens.",
   inputSchema: z.object({
-    grid_id: z.number().int(),
+    grid_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
     close_mode: z.enum(["1", "2", "3", "4"]),
   }),
   handler: async (input: Record<string, unknown>) => {

--- a/src/tools/bot/getComboDetail.ts
+++ b/src/tools/bot/getComboDetail.ts
@@ -6,7 +6,7 @@ export const getComboDetail = {
   name: 'getComboDetail',
   description: "Retrieves comprehensive details for a specific futures combo bot, including\nconfiguration (symbols, leverage, rebalancing mode), current display status,\nPnL metrics (total PnL, realized, unrealized, funding fee), portfolio position\ninfo, margin balances (total, available, margin balance), and timestamps.\n\nThe bot_id is a numeric ID obtained from createComboBot or bot listing endpoints.\n\nRate limit: 10 requests per second per UID.\n\nAgent hint: Use this endpoint to check the status and performance of a combo bot.\nThe response contains all PnL fields, position details, rebalancing stats,\nand close reason if the bot has stopped. Prefer this over other endpoints\nwhen answering questions about a specific bot's performance.",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
   }),
   handler: async (input: Record<string, unknown>) => {
     return restClient.postAuth("/v5/fcombobot/detail", input);

--- a/src/tools/bot/getFGridDetail.ts
+++ b/src/tools/bot/getFGridDetail.ts
@@ -6,7 +6,7 @@ export const getFGridDetail = {
   name: 'getFGridDetail',
   description: "Retrieves comprehensive details for a specific futures grid bot, including\nconfiguration (symbol, price range, leverage, grid type), current status,\nPnL metrics (realized, unrealized, grid profit, funding fee), position info,\nmargin balances, and timestamps.\n\nThe bot_id is a numeric ID obtained from createFGridBot or bot listing endpoints.\n\nRate limit: 10 requests per second per UID.\n\nAgent hint: Use this endpoint to check the status and performance of a grid bot.\nThe response contains all PnL fields, position details, and close reason\nif the bot has stopped. Prefer this over other endpoints when answering\nquestions about a specific bot's performance.",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
   }),
   handler: async (input: Record<string, unknown>) => {
     return restClient.postAuth("/v5/fgridbot/detail", input);

--- a/src/tools/bot/getFMartDetail.ts
+++ b/src/tools/bot/getFMartDetail.ts
@@ -6,7 +6,7 @@ export const getFMartDetail = {
   name: 'getFMartDetail',
   description: "Retrieves comprehensive details for a specific futures Martingale bot, including\nconfiguration (symbol, mode, leverage, price trigger, add position settings),\ncurrent display status, PnL metrics (realized, unrealized, total), position info\n(size, average price, balances), round progress (completed rounds, current round,\ncurrent adds), margin balances, and timestamps.\n\nThe bot_id is a numeric ID obtained from createFMartBot or bot listing endpoints.\n\nRate limit: 10 requests per second per UID.\n\nAgent hint: Use this endpoint to check the status and performance of a Martingale bot.\nThe response contains all PnL fields, position details, round progress\n(completed_rounds, current_round, current_added_pos_num), and close reason\nif the bot has stopped. Prefer this over other endpoints when answering\nquestions about a specific bot's performance.",
   inputSchema: z.object({
-    bot_id: z.number().int(),
+    bot_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
   }),
   handler: async (input: Record<string, unknown>) => {
     return restClient.postAuth("/v5/fmartingalebot/detail", input);

--- a/src/tools/bot/queryGridDetail.ts
+++ b/src/tools/bot/queryGridDetail.ts
@@ -6,7 +6,7 @@ export const queryGridDetail = {
   name: 'queryGridDetail',
   description: "Retrieves comprehensive details of a spot grid bot including symbol,\nprice range, investment amount, profit metrics (total profit, grid\nprofit, APR), arbitrage count, status, stop-loss/take-profit settings,\ntrailing stop configuration, and close reason (if closed).\n\nUse this when you need to check the current state, performance, or\nconfiguration of a specific grid bot. The grid_id is obtained from\ncreateGridBot response or grid list queries.\n\nRate limit: 10 qps per UID.\n\nAgent hint: Use this to answer questions about a specific grid bot's performance\nor status. The grid_id is a numeric ID returned by createGridBot.",
   inputSchema: z.object({
-    grid_id: z.number().int(),
+    grid_id: z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String),
   }),
   handler: async (input: Record<string, unknown>) => {
     return restClient.postAuth("/v5/grid/query-grid-detail", input);


### PR DESCRIPTION
Fixes #26.

Bybit returns bot/grid ids as 19-digit strings (e.g. `635138577566547135`), above `Number.MAX_SAFE_INTEGER`. The close/detail bot tools declared the id as `z.number().int()`, so clients had to send a JSON number and the id was rounded (`…7135` → `…7100`), making `closeGridBot`, `closeDCABot`, `queryGridDetail`, etc. fail with `grid not found` / `Not Found` for every bot created through this server.

Change: `grid_id` / `bot_id` now accept a numeric string (or a number, for backward compatibility) and are forwarded as a string, matching the REST API's own representation.

Affected tools: closeGridBot, queryGridDetail, closeFGridBot, getFGridDetail, closeDCABot, closeComboBot, getComboDetail, closeFMartBot, getFMartDetail.

`npm run typecheck` passes. Files are marked auto-generated — if the schema lives in an internal generator, the same one-line change (`z.union([z.string().regex(/^\d+$/), z.number().int()]).transform(String)`) applies there.
